### PR TITLE
Add automatic template FX (only DND5E initially)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+	printWidth: 120,
+	useTabs: true,
+	singleQuote: true
+}

--- a/tokenmagic/lang/en.json
+++ b/tokenmagic/lang/en.json
@@ -24,5 +24,20 @@
   "TMFX.minPadding.name": "Minimum padding",
   "TMFX.minPadding.hint": "The minimum padding applied to an FX.",
   "TMFX.fxPlayerPermission.name": "Permissive mode",
-  "TMFX.fxPlayerPermission.hint": "If this option is checked, non-GM players can add, modify and delete FX on placeables which they do not own. A GM must be connected."
+  "TMFX.fxPlayerPermission.hint": "If this option is checked, non-GM players can add, modify and delete FX on placeables which they do not own. A GM must be connected.",
+  "TMFX.settings.autoTemplateEnabled.name": "Enable automatic template effects",
+  "TMFX.settings.autoTemplateEnabled.hint": "Disabling this option will disable all automatic template effects. NOTE: Only affects newly placed templates.",
+  "TMFX.settings.autoTemplateSettings.button.name": "Automatic Template Effects",
+  "TMFX.settings.autoTemplateSettings.button.label": "Template Settings",
+  "TMFX.settings.autoTemplateSettings.button.hint": "On game systems that are supported, template effects can be enabled based on the type of spell area and damage type, or with overrides for specific spells.",
+  "TMFX.settings.autoTemplateSettings.tabs.general": "General",
+  "TMFX.settings.autoTemplateSettings.tabs.categories": "Categories",
+  "TMFX.settings.autoTemplateSettings.tabs.overrides": "Overrides",
+  "TMFX.settings.autoTemplateSettings.texture.label": "Texture (optional)",
+  "TMFX.settings.autoTemplateSettings.texture.hint": "Optionally specify a texture for the filter, if one is not specified, an appropriate texture will be used.",
+  "TMFX.settings.autoTemplateSettings.unsupported": "This feature is currently unsupportted for this game system, contributions to enable more systems would be more than welcome!",
+  "TMFX.settings.autoTemplateSettings.overrides.introduction": "You may configure overrides for individual items/spells here. Enter the name of the item/spell as it appears in your Items/Compendiums in the Target field, and configure your preferred settings.",
+  "TMFX.settings.autoTemplateSettings.overrides.add": "Add Override",
+  "TMFX.settings.autoTemplateSettings.dialog.title": "Token Magic Template Settings",
+  "TMFX.save": "Save"
 }

--- a/tokenmagic/module.json
+++ b/tokenmagic/module.json
@@ -10,6 +10,7 @@
     "libs/filters/pixi-filters.js"
   ],
   "esmodules": [
+    "module/settings.js",
     "module/tokenmagic.js",
     "module/proto/PlaceableObjectProto.js",
     "fx/Anime.js",
@@ -60,9 +61,10 @@
     "fx/filters/FilterPixelate.js",
     "fx/filters/FilterSpiderWeb.js",
     "fx/filters/proto/FilterProto.js"
-
   ],
-  "styles": [],
+  "styles": [
+    "styles/tokenmagic.css"
+  ],
   "packs": [
     {
       "name": "tmMacros",

--- a/tokenmagic/module/autoTemplate/dnd5e.js
+++ b/tokenmagic/module/autoTemplate/dnd5e.js
@@ -1,0 +1,182 @@
+import { defaultOpacity, emptyPreset } from '../constants.js';
+
+export class AutoTemplateDND5E {
+	static get defaultConfiguration() {
+		const defaultConfig = {
+			categories: {},
+			overrides: {
+				0: {
+					target: 'Stinking Cloud',
+					opacity: 0.5,
+					tint: '#00a80b',
+					preset: 'Smoky Area',
+					texture: null,
+				},
+				1: {
+					target: 'Web',
+					opacity: 0.5,
+					tint: '#808080',
+					preset: 'Spider Web 2',
+					texture: null,
+				},
+			},
+		};
+
+		Object.keys(CONFIG.DND5E.damageTypes).forEach((dmgType) => {
+			if (defaultConfig.categories[dmgType] == undefined) {
+				const config = { opacity: defaultOpacity, tint: null };
+				switch (dmgType.toLowerCase()) {
+					case 'acid':
+						config.tint = '#2d8000';
+						config.opacity = 0.6;
+						break;
+					case 'cold':
+						config.tint = '#47b3ff';
+						break;
+					case 'necrotic':
+						config.tint = '#502673';
+						break;
+					case 'poison':
+						config.tint = '#00a80b';
+						break;
+					case 'psychic':
+						config.tint = '#8000ff';
+						break;
+					case 'thunder':
+						config.tint = '#0060ff';
+						break;
+					default:
+						break;
+				}
+				defaultConfig.categories[dmgType] = config;
+			}
+			Object.keys(CONFIG.MeasuredTemplate.types).forEach((tplType) => {
+				const config = { preset: emptyPreset, texture: null }
+				switch (dmgType.toLowerCase()) {
+					case 'acid':
+						config.preset = 'Watery Surface 2';
+						break;
+					case 'cold':
+						config.preset = 'Thick Fog';
+						break;
+					case 'fire':
+						config.preset = 'Flames';
+						break;
+					case 'force':
+						config.preset = 'Waves 3';
+						break;
+					case 'lightning':
+						config.preset = 'Shock';
+						break;
+					case 'necrotic':
+						config.preset = 'Smoke Filaments';
+						break;
+					case 'poison':
+						config.preset = 'Smoky Area';
+						break;
+					case 'psychic':
+						config.preset = 'Classic Rays';
+						break;
+					case 'radiant':
+						config.preset = 'Annihilating Rays';
+						break;
+					case 'thunder':
+						config.preset = 'Waves';
+						break;
+					default:
+						break;
+				}
+				defaultConfig.categories[dmgType][tplType] = config;
+			});
+		});
+
+		return defaultConfig;
+	}
+
+	constructor() {
+		this._origFromItem = null;
+		this._importedJS = null;
+		this._abilityTemplate = null;
+	}
+
+	async configure(enabled = false) {
+		if (!this._isDnd5e) return;
+
+		if (!enabled) {
+			// Restore original function if we previously patched it
+			if (this._origFromItem != null) {
+				this._abilityTemplate.fromItem = this._origFromItem;
+				this._origFromItem = null;
+			}
+			return;
+		}
+
+		if (this._importedJS == null) {
+			this._importedJS = (await import('../../../../systems/dnd5e/module/pixi/ability-template.js'));
+		}
+		if (this._abilityTemplate == null) {
+			this._abilityTemplate = this._importedJS.default || this._importedJS.AbilityTemplate;
+		}
+
+		this._origFromItem = this._abilityTemplate.fromItem;
+		this._abilityTemplate.fromItem = this._fromItem.bind(this);
+	}
+
+	get _isDnd5e() {
+		return game.system.id === 'dnd5e';
+	}
+
+	_fromConfig(config, template) {
+		if (config.preset && config.preset != '' && config.preset != 'NOFX') {
+			template.data.tmfxPreset = config.preset;
+		}
+		if (config.texture && config.texture != '') {
+			template.data.texture = config.texture;
+		}
+		if (config.tint && config.tint != '') {
+			template.data.tmfxTint = config.tint;
+		}
+		template.data.tmfxTextureAlpha = config.opacity;
+	}
+
+	_fromOverrides(overrides = [], item, template) {
+		let config = overrides.find((el) => el.target.toLowerCase() == item.name.toLowerCase());
+		if (!config) {
+			return false;
+		}
+		this._fromConfig(config, template);
+		return true;
+	}
+
+	_fromCategories(categories = {}, item, template) {
+		if (!item.hasDamage) {
+			return false;
+		}
+		let dmgSettings = categories[item.data.data.damage.parts[0][1]] || {};
+		let config = dmgSettings[template.data.t];
+		if (!config) {
+			return false;
+		}
+		this._fromConfig(mergeObject(config, { opacity: dmgSettings.opacity, tint: dmgSettings.tint }, true, true), template);
+		return true;
+	}
+
+	_fromItem(item) {
+		const template = this._origFromItem.bind(this._abilityTemplate)(item);
+		if (!template) {
+			return template;
+		}
+		let hasPreset = template.hasOwnProperty("tmfxPreset");
+		if (hasPreset) {
+			return template;
+		}
+		const settings = game.settings.get('tokenmagic', 'autoTemplateSettings');
+		let updated = this._fromOverrides(Object.values(settings.overrides), item, template);
+		if (!updated) {
+			this._fromCategories(settings.categories, item, template);
+		}
+		return template;
+	}
+}
+
+export const dnd5eTemplates = new AutoTemplateDND5E();

--- a/tokenmagic/module/constants.js
+++ b/tokenmagic/module/constants.js
@@ -1,0 +1,2 @@
+export const defaultOpacity = 0.5;
+export const emptyPreset = 'NOFX';

--- a/tokenmagic/module/proto/PlaceableObjectProto.js
+++ b/tokenmagic/module/proto/PlaceableObjectProto.js
@@ -116,7 +116,7 @@ MeasuredTemplate.prototype.update = (function () {
         let hasTexture = data.hasOwnProperty("texture");
         let hasPresetData = data.hasOwnProperty("tmfxPreset");
         if (hasPresetData && data.tmfxPreset !== 'NOFX') {
-            let defaultTexture = Magic._getPresetTemplateDefaultTexture(data.tmfxPreset.slice(5));
+            let defaultTexture = Magic._getPresetTemplateDefaultTexture(data.tmfxPreset);
             if (!(defaultTexture == null)) {
                 if (data.texture === '' || data.texture.includes('/modules/tokenmagic/fx/assets/templates/'))
                     data.texture = defaultTexture;

--- a/tokenmagic/module/settings.js
+++ b/tokenmagic/module/settings.js
@@ -1,0 +1,258 @@
+import { presets as defaultPresets, PresetsLibrary } from "../fx/presets/defaultpresets.js";
+import { DataVersion } from "../migration/migration.js";
+import { TokenMagic } from './tokenmagic.js';
+import { AutoTemplateDND5E, dnd5eTemplates } from "./autoTemplate/dnd5e.js";
+import { defaultOpacity, emptyPreset } from './constants.js';
+
+const Magic = TokenMagic();
+
+export class TokenMagicSettings extends FormApplication {
+	static init() {
+		const menuAutoTemplateSettings = {
+			key: 'autoTemplateSettings',
+			config: {
+				name: game.i18n.localize('TMFX.settings.autoTemplateSettings.button.name'),
+				label: game.i18n.localize('TMFX.settings.autoTemplateSettings.button.label'),
+				hint: game.i18n.localize('TMFX.settings.autoTemplateSettings.button.hint'),
+				type: TokenMagicSettings,
+				restricted: true,
+			},
+		};
+
+		const settingAutoTemplateSettings = {
+			key: 'autoTemplateSettings',
+			config: {
+				name: game.i18n.localize('TMFX.settings.autoTemplateSettings.name'),
+				hint: game.i18n.localize('TMFX.settings.autoTemplateSettings.hint'),
+				scope: 'world',
+				config: false,
+				default: {},
+				type: Object,
+			},
+		};
+
+		let hasAutoTemplates = false;
+		switch (game.system.id) {
+			case 'dnd5e':
+				hasAutoTemplates = true;
+				game.settings.registerMenu('tokenmagic', menuAutoTemplateSettings.key, menuAutoTemplateSettings.config);
+				game.settings.register(
+					'tokenmagic',
+					settingAutoTemplateSettings.key,
+					mergeObject(settingAutoTemplateSettings.config, {
+						default: AutoTemplateDND5E.defaultConfiguration
+					}, true, true),
+				);
+				break;
+			default:
+				break;
+		}
+
+		game.settings.register('tokenmagic', 'autoTemplateEnabled', {
+			name: game.i18n.localize('TMFX.settings.autoTemplateEnabled.name'),
+			hint: game.i18n.localize('TMFX.settings.autoTemplateEnabled.hint'),
+			scope: 'client',
+			config: hasAutoTemplates,
+			default: hasAutoTemplates,
+			type: Boolean,
+			onChange: (value) => TokenMagicSettings.configureAutoTemplate(value),
+		});
+
+		game.settings.register("tokenmagic", "useAdditivePadding", {
+			name: game.i18n.localize("TMFX.useMaxPadding.name"),
+			hint: game.i18n.localize("TMFX.useMaxPadding.hint"),
+			scope: "world",
+			config: true,
+			default: false,
+			type: Boolean
+		});
+
+		game.settings.register("tokenmagic", "minPadding", {
+			name: game.i18n.localize("TMFX.minPadding.name"),
+			hint: game.i18n.localize("TMFX.minPadding.hint"),
+			scope: "world",
+			config: true,
+			default: 50,
+			type: Number
+		});
+
+		game.settings.register("tokenmagic", "fxPlayerPermission", {
+			name: game.i18n.localize("TMFX.fxPlayerPermission.name"),
+			hint: game.i18n.localize("TMFX.fxPlayerPermission.hint"),
+			scope: "world",
+			config: true,
+			default: false,
+			type: Boolean
+		});
+
+		game.settings.register("tokenmagic", "importOverwrite", {
+			name: game.i18n.localize("TMFX.importOverwrite.name"),
+			hint: game.i18n.localize("TMFX.importOverwrite.hint"),
+			scope: "world",
+			config: true,
+			default: false,
+			type: Boolean
+		});
+
+		game.settings.register("tokenmagic", "presets", {
+			name: "Token Magic FX presets",
+			hint: "Token Magic FX presets",
+			scope: "world",
+			config: false,
+			default: defaultPresets,
+			type: Object
+		});
+
+		game.settings.register("tokenmagic", "migration", {
+			name: "TMFX Data Version",
+			hint: "TMFX Data Version",
+			scope: "world",
+			config: false,
+			default: DataVersion.ARCHAIC,
+			type: String
+		});
+
+		loadTemplates([
+			'modules/tokenmagic/templates/settings/settings.html',
+			'modules/tokenmagic/templates/settings/dnd5e/categories.html',
+			'modules/tokenmagic/templates/settings/dnd5e/overrides.html',
+		]);
+	}
+
+	static configureAutoTemplate(enabled = false) {
+		switch (game.system.id) {
+			case 'dnd5e':
+				dnd5eTemplates.configure(enabled);
+				break;
+			default:
+				break;
+		}
+	}
+
+	/** @override */
+	static get defaultOptions() {
+		return {
+			...super.defaultOptions,
+			template: 'modules/tokenmagic/templates/settings/settings.html',
+			height: 'auto',
+			title: game.i18n.localize('TMFX.settings.autoTemplateSettings.dialog.title'),
+			width: 600,
+			classes: ['tokenmagic', 'settings'],
+			tabs: [
+				{
+					navSelector: '.tabs',
+					contentSelector: 'form',
+					initial: 'name',
+				},
+			],
+			submitOnClose: false,
+		};
+	}
+
+	constructor(object = {}, options) {
+		super(object, options);
+	}
+
+	getSettingsData() {
+		let settingsData = {
+			'autoTemplateEnable': game.settings.get('tokenmagic', 'autoTemplateEnabled'),
+		}
+		switch (game.system.id) {
+			case 'dnd5e':
+				settingsData['autoTemplateSettings'] = game.settings.get('tokenmagic', 'autoTemplateSettings');
+				break;
+			default:
+				break;
+		}
+		return settingsData;
+	}
+
+	/** @override */
+	getData() {
+		let data = super.getData();
+		data.hasAutoTemplates = false;
+		switch (game.system.id) {
+			case 'dnd5e':
+				data.hasAutoTemplates = true
+				data.dmgTypes = CONFIG.DND5E.damageTypes;
+				data.templateTypes = CONFIG.MeasuredTemplate.types;
+				break;
+			default:
+				break;
+		}
+		data.presets = Magic.getPresets(PresetsLibrary.TEMPLATE).sort(function (a, b) {
+			if (a.name < b.name) return -1;
+			if (a.name > b.name) return 1;
+			return 0;
+		});
+		data.system = { id: game.system.id, title: game.system.data.title };
+		data.settings = this.getSettingsData();
+		data.submitText = game.i18n.localize('TMFX.save');
+		return data;
+	}
+
+	/** @override */
+	async _updateObject(_, formData) {
+		const data = expandObject(formData);
+		for (let [key, value] of Object.entries(data)) {
+			if (key == 'autoTemplateSettings' && value.overrides) {
+				const compacted = {};
+				Object.values(value.overrides).forEach((val, idx) => compacted[idx] = val);
+				value.overrides = compacted;
+			}
+			await game.settings.set('tokenmagic', key, value);
+		}
+	}
+
+	/** @override */
+	activateListeners(html) {
+		super.activateListeners(html);
+
+		html.find('button.add-override').click(this._onAddOverride.bind(this));
+		html.find('button.remove-override').click(this._onRemoveOverride.bind(this));
+	}
+
+	async _onAddOverride(event) {
+		event.preventDefault();
+		let idx = 0;
+		const entries = event.target.closest('div.tab').querySelectorAll('div.override-entry');
+		const last = entries[entries.length - 1];
+		if (last) {
+			idx = last.dataset.idx + 1;
+		}
+		let updateData = {}
+		updateData[`autoTemplateSettings.overrides.${idx}.target`] = '';
+		updateData[`autoTemplateSettings.overrides.${idx}.opacity`] = defaultOpacity;
+		updateData[`autoTemplateSettings.overrides.${idx}.tint`] = null;
+		updateData[`autoTemplateSettings.overrides.${idx}.preset`] = emptyPreset;
+		updateData[`autoTemplateSettings.overrides.${idx}.texture`] = null;
+		await this._onSubmit(event, { updateData: updateData, preventClose: true });
+		this.render();
+	}
+
+	async _onRemoveOverride(event) {
+		event.preventDefault();
+		let idx = event.target.dataset.idx;
+		const el = event.target.closest(`div[data-idx="${idx}"]`);
+		if (!el) {
+			return true;
+		}
+		el.remove();
+		await this._onSubmit(event, { preventClose: true });
+		this.render();
+	}
+}
+
+Hooks.once("init", () => {
+	// Extracted from https://github.com/leapfrogtechnology/just-handlebars-helpers/
+	Handlebars.registerHelper('concat', function (...params) {
+		// Ignore the object appended by handlebars.
+		if (typeof params[params.length - 1] === 'object') {
+			params.pop();
+		}
+
+		return params.join('');
+	});
+	TokenMagicSettings.init();
+	TokenMagicSettings.configureAutoTemplate(game.settings.get('tokenmagic', 'autoTemplateEnabled'));
+});

--- a/tokenmagic/styles/tokenmagic.css
+++ b/tokenmagic/styles/tokenmagic.css
@@ -1,0 +1,30 @@
+.tokenmagic.settings nav.tabs {
+	flex: 0 0 32px;
+	line-height: 32px;
+	font-size: 16px;
+	border-bottom: 1px solid #000;
+}
+
+.tokenmagic.settings section.content {
+	border-top: 1px solid #b5b3a4;
+}
+
+.tokenmagic.settings section.content .settings-list {
+	max-height: calc(100vh - 150px);
+	overflow-y: auto;
+	padding-right: 0.5em;
+}
+
+.tokenmagic.settings div.override-entry {
+	padding: 0.5em 0;
+	border-top: 1px solid #b5b3a4;
+}
+
+.tokenmagic.settings div.remove-override-wrapper {
+	flex: 0;
+	margin-left: 0.5em;
+}
+
+.tokenmagic.settings footer.add-override-wrapper {
+	margin-bottom: 0.5em;
+}

--- a/tokenmagic/templates/settings/dnd5e/categories.html
+++ b/tokenmagic/templates/settings/dnd5e/categories.html
@@ -1,0 +1,85 @@
+<div class='settings-list'>
+	{{#each dmgTypes as |dmgType dmgKey|}}
+		<h2>
+			{{dmgType}}
+		</h2>
+		<div class='form-group'>
+			<label for="autoTemplateSettings.categories.{{dmgKey}}.opacity">
+				{{localize 'TMFX.template.opacity'}}
+			</label>
+			<div class='form-fields'>
+				<input
+					type='range'
+					name="autoTemplateSettings.categories.{{dmgKey}}.opacity"
+					value="{{lookup (lookup @root.settings.autoTemplateSettings.categories dmgKey) 'opacity'}}"
+					min='0.0'
+					max='1.0'
+					step='0.05'
+					data-dtype='Number'
+				/>
+				<span class='range-value'>
+					{{lookup (lookup @root.settings.autoTemplateSettings.categories dmgKey) 'opacity'}}
+				</span>
+			</div>
+		</div>
+		<div class='form-group'>
+			<label for="autoTemplateSettings.categories.{{dmgKey}}.tint">
+				{{localize 'TMFX.template.tint'}}
+			</label>
+			<div class='form-fields'>
+				<input
+					class='color'
+					type='text'
+					name="autoTemplateSettings.categories.{{dmgKey}}.tint"
+					value="{{lookup (lookup @root.settings.autoTemplateSettings.categories dmgKey) 'tint'}}"
+				/>
+				<input
+					type='color'
+					value="{{lookup (lookup @root.settings.autoTemplateSettings.categories dmgKey) 'tint'}}"
+					data-edit="autoTemplateSettings.categories.{{dmgKey}}.tint"
+				/>
+			</div>
+		</div>
+		{{#each @root.templateTypes as |tplType tplKey|}}
+			<hr />
+			<h3>
+				{{tplType}}
+			</h3>
+			<div class='form-group'>
+				<label for="autoTemplateSettings.categories.{{dmgKey}}.{{tplKey}}.preset">
+					{{localize 'TMFX.template.fx'}}
+				</label>
+				<select name="autoTemplateSettings.categories.{{dmgKey}}.{{tplKey}}.preset" data-dtype='String'>
+					{{#select (lookup (lookup (lookup @root.settings.autoTemplateSettings.categories dmgKey) tplKey) 'preset')}}
+						<option value='NOFX'></option>
+						{{#each @root.presets as |preset|}}
+							<option value="{{preset.name}}">
+								{{preset.name}}
+							</option>
+						{{/each}}
+					{{/select}}
+				</select>
+			</div>
+			<div class='form-group'>
+				<label for="autoTemplateSettings.categories.{{dmgKey}}.{{tplKey}}.texture">
+					{{localize 'TMFX.settings.autoTemplateSettings.texture.label'}}
+				</label>
+				<div class='form-fields'>
+					{{
+						filePicker
+						target=(concat (concat (concat 'autoTemplateSettings.categories.' dmgKey) tplKey) '.texture')
+						type='image'
+					}}
+					<input
+						class='image'
+						type='text'
+						name="autoTemplateSettings.categories.{{dmgKey}}.{{tplKey}}.texture"
+						placeholder='path/image.png'
+						value="{{lookup (lookup (lookup @root.settings.autoTemplateSettings.categories dmgKey) tplKey) 'texture'}}"
+						data-dtype='String'
+					/>
+				</div>
+			</div>
+		{{/each}}
+	{{/each}}
+</div>

--- a/tokenmagic/templates/settings/dnd5e/overrides.html
+++ b/tokenmagic/templates/settings/dnd5e/overrides.html
@@ -1,0 +1,101 @@
+<div class='settings-list'>
+	<p>
+		{{localize 'TMFX.settings.autoTemplateSettings.overrides.introduction'}}
+	</p>
+	{{#each settings.autoTemplateSettings.overrides as |override idx|}}
+		<div class='flexrow override-entry' data-idx="{{idx}}">
+			<div class='flexcol'>
+				<div class='form-group'>
+					<label for="autoTemplateSettings.overrides.{{idx}}.target">
+						Target
+					</label>
+					<div class='form-fields'>
+						<input
+							type='text'
+							name="autoTemplateSettings.overrides.{{idx}}.target"
+							value="{{lookup (lookup @root.settings.autoTemplateSettings.overrides idx) 'target'}}"
+						/>
+					</div>
+				</div>
+				<div class='form-group'>
+					<label for="autoTemplateSettings.overrides.{{idx}}.opacity">
+						{{localize 'TMFX.template.opacity'}}
+					</label>
+					<div class='form-fields'>
+						<input
+							type='range'
+							name="autoTemplateSettings.overrides.{{idx}}.opacity"
+							value="{{lookup (lookup @root.settings.autoTemplateSettings.overrides idx) 'opacity'}}"
+							min='0.0'
+							max='1.0'
+							step='0.05'
+							data-dtype='Number'
+						/>
+						<span class='range-value'>
+							{{lookup (lookup @root.settings.autoTemplateSettings.overrides idx) 'opacity'}}
+						</span>
+					</div>
+				</div>
+				<div class='form-group'>
+					<label for="autoTemplateSettings.overrides.{{idx}}.tint">
+						{{localize 'TMFX.template.tint'}}
+					</label>
+					<div class='form-fields'>
+						<input
+							class='color'
+							type='text'
+							name="autoTemplateSettings.overrides.{{idx}}.tint"
+							value="{{lookup (lookup @root.settings.autoTemplateSettings.overrides idx) 'tint'}}"
+						/>
+						<input
+							type='color'
+							value="{{lookup (lookup @root.settings.autoTemplateSettings.overrides idx) 'tint'}}"
+							data-edit="autoTemplateSettings.overrides.{{idx}}.tint"
+						/>
+					</div>
+				</div>
+				<div class='form-group'>
+					<label for="autoTemplateSettings.overrides.{{idx}}.preset">
+						{{localize 'TMFX.template.fx'}}
+					</label>
+					<select name="autoTemplateSettings.overrides.{{idx}}.preset" data-dtype='String'>
+						{{#select (lookup (lookup @root.settings.autoTemplateSettings.overrides idx) 'preset')}}
+							<option value='NOFX'></option>
+							{{#each @root.presets as |preset|}}
+								<option value="{{preset.name}}">
+									{{preset.name}}
+								</option>
+							{{/each}}
+						{{/select}}
+					</select>
+				</div>
+				<div class='form-group'>
+					<label for="autoTemplateSettings.overrides.{{idx}}.texture">
+						{{localize 'TMFX.settings.autoTemplateSettings.texture.label'}}
+					</label>
+					<div class='form-fields'>
+						{{filePicker target=(concat (concat 'autoTemplateSettings.overrides.' idx) '.texture') type='image'}}
+						<input
+							class='image'
+							type='text'
+							name="autoTemplateSettings.overrides.{{idx}}.texture"
+							placeholder='path/image.png'
+							value="{{lookup (lookup @root.settings.autoTemplateSettings.overrides idx) 'texture'}}"
+							data-dtype='String'
+						/>
+					</div>
+				</div>
+			</div>
+			<div class='flexcol remove-override-wrapper'>
+				<button class='remove-override' data-idx="{{idx}}">
+					<i class='far fa-trash-alt'></i>
+				</button>
+			</div>
+		</div>
+	{{/each}}
+</div>
+<footer class='sheet-footer flexrow add-override-wrapper'>
+	<button class='add-override'>
+		<i class='far fa-plus-square'></i>{{localize 'TMFX.settings.autoTemplateSettings.overrides.add'}}
+	</button>
+</footer>

--- a/tokenmagic/templates/settings/settings.html
+++ b/tokenmagic/templates/settings/settings.html
@@ -1,0 +1,40 @@
+<form class="flexcol" autocomplete='off'>
+	<nav class='sheet-tabs tabs' data-group="sections">
+		<a class='item' data-tab='categories'>
+			{{localize 'TMFX.settings.autoTemplateSettings.tabs.categories'}}
+		</a>
+		<a class='item' data-tab='overrides'>
+			{{localize 'TMFX.settings.autoTemplateSettings.tabs.overrides'}}
+		</a>
+	</nav>
+
+	{{#*inline 'unsupported'}}
+		<h1>
+			{{system.title}}
+		</h1>
+		<p>
+			{{localize 'TMFX.settings.autoTemplateSettings.unsupported'}}
+		</p>
+		<p>
+			<a href='https://github.com/Feu-Secret/Tokenmagic/' target='_blank'>
+				https://github.com/Feu-Secret/Tokenmagic/
+			</a>
+		</p>
+	{{/inline}}
+
+	<section class='content'>
+		<div class='tab' data-tab='categories' data-group='sections'>
+			{{#> (concat (concat 'modules/tokenmagic/templates/settings/' system.id) '/categories.html')}}
+				{{> unsupported}}
+			{{/undefined}}
+		</div>
+		<div class='tab' data-tab='overrides' data-group='sections'>
+			{{#> (concat (concat 'modules/tokenmagic/templates/settings/' system.id) '/overrides.html')}}
+				{{> unsupported}}
+			{{/undefined}}
+		</div>
+	</section>
+	<footer class='sheet-footer flexrow'>
+		<button type='submit' name='submit' value='1'><i class='far fa-save'></i>{{submitText}}</button>
+	</footer>
+</form>


### PR DESCRIPTION
This is a somewhat large change, I debated whether this should live in its own module or not, but I think the integration is nice. This change allows auto-applying template FX (for DND5E) based on spell damage type and template shape. In addition, it allows overriding applied effects based on the name of the Item/spell that triggered the template creation.

I've tried to think about future adding of systems other than 5E when writing this, but that system has been my primary focus for this change.

I will add some line comments for a couple of areas I changed existing code, to make sure I've not overlooked anything.