### PR TITLE
Add option to toggle the default template grid only on hover

### DIFF
--- a/tokenmagic/lang/en.json
+++ b/tokenmagic/lang/en.json
@@ -27,6 +27,8 @@
   "TMFX.fxPlayerPermission.hint": "If this option is checked, non-GM players can add, modify and delete FX on placeables which they do not own. A GM must be connected.",
   "TMFX.settings.autoTemplateEnabled.name": "Enable automatic template effects",
   "TMFX.settings.autoTemplateEnabled.hint": "Disabling this option will disable all automatic template effects. NOTE: Only affects newly placed templates.",
+  "TMFX.settings.defaultTemplateOnHover.name": "Default template grid on hover",
+  "TMFX.settings.defaultTemplateOnHover.hint": "Display the default template grid only when hovering on the template layer.",
   "TMFX.settings.autoTemplateSettings.button.name": "Automatic Template Effects",
   "TMFX.settings.autoTemplateSettings.button.label": "Template Settings",
   "TMFX.settings.autoTemplateSettings.button.hint": "On game systems that are supported, template effects can be enabled based on the type of spell area and damage type, or with overrides for specific spells.",

--- a/tokenmagic/module/proto/DefaultTemplateOnHover.js
+++ b/tokenmagic/module/proto/DefaultTemplateOnHover.js
@@ -1,0 +1,35 @@
+class DefaultTemplateOnHover {
+	constructor() {
+		this._origRefresh = null;
+	}
+
+	configure(enabled = false) {
+		if (!enabled) {
+			// Restore original function when setting toggled off
+			if (this._origRefresh !== null) {
+				MeasuredTemplate.prototype.refresh = this._origRefresh;
+				this._origRefresh = null;
+			}
+			return;
+		}
+		this._origRefresh = MeasuredTemplate.prototype.refresh;
+		MeasuredTemplate.prototype.refresh = this.refreshFn();
+	}
+
+	refreshFn() {
+		const self = this;
+		return function () {
+			if (game.settings.get('tokenmagic', 'defaultTemplateOnHover')) {
+				const hl = canvas.grid.getHighlightLayer(`Template.${this.id}`);
+				if (this.texture && this.texture !== '') {
+					hl.renderable = this._hover;
+				} else {
+					hl.renderable = true;
+				}
+			}
+			self._origRefresh.apply(this);
+		};
+	}
+}
+
+export const defaultTemplateOnHover = new DefaultTemplateOnHover();

--- a/tokenmagic/module/settings.js
+++ b/tokenmagic/module/settings.js
@@ -2,6 +2,7 @@ import { presets as defaultPresets, PresetsLibrary } from "../fx/presets/default
 import { DataVersion } from "../migration/migration.js";
 import { TokenMagic } from './tokenmagic.js';
 import { AutoTemplateDND5E, dnd5eTemplates } from "./autoTemplate/dnd5e.js";
+import { defaultTemplateOnHover } from "./proto/DefaultTemplateOnHover.js";
 import { defaultOpacity, emptyPreset } from './constants.js';
 
 const Magic = TokenMagic();
@@ -56,6 +57,16 @@ export class TokenMagicSettings extends FormApplication {
 			default: hasAutoTemplates,
 			type: Boolean,
 			onChange: (value) => TokenMagicSettings.configureAutoTemplate(value),
+		});
+
+		game.settings.register('tokenmagic', 'defaultTemplateOnHover', {
+			name: game.i18n.localize('TMFX.settings.defaultTemplateOnHover.name'),
+			hint: game.i18n.localize('TMFX.settings.defaultTemplateOnHover.hint'),
+			scope: 'client',
+			config: true,
+			default: hasAutoTemplates,
+			type: Boolean,
+			onChange: (value) => TokenMagicSettings.configureDefaultTemplateOnHover(value),
 		});
 
 		game.settings.register("tokenmagic", "useAdditivePadding", {
@@ -127,6 +138,10 @@ export class TokenMagicSettings extends FormApplication {
 			default:
 				break;
 		}
+	}
+
+	static configureDefaultTemplateOnHover(enabled = false) {
+		defaultTemplateOnHover.configure(enabled);
 	}
 
 	/** @override */
@@ -256,4 +271,5 @@ Hooks.once("init", () => {
 	});
 	TokenMagicSettings.init();
 	TokenMagicSettings.configureAutoTemplate(game.settings.get('tokenmagic', 'autoTemplateEnabled'));
+	TokenMagicSettings.configureDefaultTemplateOnHover(game.settings.get('tokenmagic', 'defaultTemplateOnHover'));
 });


### PR DESCRIPTION
Templates without textures will display the grid as usual, but when this option is enabled (default when auto-templates are available) the grid will only display for textured templates when the template anchor is hovered (or when holding ALT for all templates) on the template layer.