### PR TITLE
Use refresh to disable monkey-patches

### DIFF
--- a/tokenmagic/module/autoTemplate/dnd5e.js
+++ b/tokenmagic/module/autoTemplate/dnd5e.js
@@ -103,10 +103,15 @@ export class AutoTemplateDND5E {
 		if (!this._isDnd5e) return;
 
 		if (!enabled) {
-			// Restore original function if we previously patched it
 			if (this._origFromItem !== null) {
-				this._abilityTemplate.fromItem = this._origFromItem;
-				this._origFromItem = null;
+				// Restoring the original function when setting toggled off is unsafe
+				// in the case that there is another module patching the same function
+				// and they're loaded after us, so resort to refresh here.
+				/*
+					this._abilityTemplate.fromItem = this._origFromItem;
+					this._origFromItem = null;
+				*/
+				window.location.reload();
 			}
 			return;
 		}

--- a/tokenmagic/module/proto/DefaultTemplateOnHover.js
+++ b/tokenmagic/module/proto/DefaultTemplateOnHover.js
@@ -5,10 +5,15 @@ class DefaultTemplateOnHover {
 
 	configure(enabled = false) {
 		if (!enabled) {
-			// Restore original function when setting toggled off
 			if (this._origRefresh !== null) {
-				MeasuredTemplate.prototype.refresh = this._origRefresh;
-				this._origRefresh = null;
+				// Restoring the original function when setting toggled off is unsafe
+				// in the case that there is another module patching the same function
+				// and they're loaded after us, so resort to refresh here.
+				/*
+					MeasuredTemplate.prototype.refresh = this._origRefresh;
+					this._origRefresh = null;
+				*/
+				window.location.reload();
 			}
 			return;
 		}


### PR DESCRIPTION
If another module patches the same functions as us, and is loaded after
us, the function we restore would overwrite their changes, so instead
resort to reloading the page when we disable a monkey-patching feature.