### PR TITLE
Fix _fromCategories matching only first damage type

### DIFF
--- a/tokenmagic/module/autoTemplate/dnd5e.js
+++ b/tokenmagic/module/autoTemplate/dnd5e.js
@@ -157,8 +157,19 @@ export class AutoTemplateDND5E {
 		if (!item.hasDamage) {
 			return false;
 		}
-		let dmgSettings = categories[item.data.data.damage.parts[0][1]] || {};
-		let config = dmgSettings[template.data.t];
+
+		let config, dmgSettings;
+
+		// some items/spells have multiple damage types
+		// this loop looks over all the types until it finds one with a valid fx preset
+		for (const [_, dmgType] of item.data.data.damage.parts) {
+			dmgSettings = categories[dmgType] || {};
+			config = dmgSettings[template.data.t];
+
+			if (config && config.preset !== emptyPreset) {
+				break;
+			}
+		}
 		if (!config) {
 			return false;
 		}


### PR DESCRIPTION
Addresses #69 by iterating through item damage types until a preset is encountered instead of only accessing the preset of the first damage type as before. 

This does not attempt to merge fx when there are multiple damage types with valid presets.