### PR TITLE
Release scripts

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,66 @@
+name: Release Creation
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # run npm install and npm run build
+      - name: Install Dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+
+      #Substitute the Manifest and Download URLs in the module.json
+      - name: Substitute Manifest and Download Links For Versioned Ones
+        id: sub_manifest_link_version
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: 'tokenmagic/module.json'
+        env:
+          version: ${{github.event.release.tag_name}}
+          manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
+          download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/tokenmagic.zip
+
+      # create a zip file with all files required by the module to add to the release
+      - run: cd tokenmagic && zip -r ./tokenmagic.zip module.json fx/ gui/ import/ lang/ libs/ migration/ module/ *.js  *.js.map
+
+      # Create a release for this specific version
+      - name: Update Release with Files
+        id: create_version_release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true # set this to false if you want to prevent updating existing releases
+          name: ${{ github.event.release.name }}
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: 'tokenmagic/module.json, tokenmagic/tokenmagic.zip'
+          tag: ${{ github.event.release.tag_name }}
+          body: ${{ github.event.release.body }}
+
+      # Update the 'latest' release
+      - name: Create Release
+        id: create_latest_release
+        uses: ncipollo/release-action@v1
+        if: endsWith(github.ref, 'master')
+        with:
+          allowUpdates: true
+          name: Latest
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: 'tokenmagic/module.json,tokenmagic/tokenmagic.zip'
+          tag: latest
+          body: ${{ github.event.release.body }}
+      - name: Publish Module to FoundryVTT Website
+        id: publish-to-foundry-website
+        uses: cs96and/FoundryVTT-release-package@v1
+        with:
+          package-token: ${{ secrets.PACKAGE_TOKEN }}
+          manifest-url: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json


### PR DESCRIPTION
This adds a release script that builds the module when a release is created with a proper tag (in the form of version number, like 0.6.6.0) and publishes it to the Foundry website. The release name can be anything, as well as its content - the script will add the 

The sample release results (except publishing package to Foundry website) can be found here: https://github.com/Rughalt/Tokenmagic/releases/tag/0.6.7.0