### PR TITLE
Skip MeasuredTemplate placeables whose _draw left them incomplete

### DIFF
--- a/tokenmagic/module/settings.js
+++ b/tokenmagic/module/settings.js
@@ -413,7 +413,14 @@ Hooks.once('init', () => {
 			canvas.stage.on('mousemove', (event) => {
 				const { x: mx, y: my } = event.data.getLocalPosition(canvas.templates);
 				for (const template of canvas.templates.placeables) {
+					// A template whose _draw aborted (e.g. legacy scene data carried
+					// over from a system that no longer creates MeasuredTemplates, or
+					// a missing/failing texture) leaves `template.template` and the
+					// grid highlight layer undefined. Skip those rather than crash
+					// the pointermove pipeline.
+					if (!template.template) continue;
 					const hl = canvas.interface.grid.getHighlightLayer(template.highlightId);
+					if (!hl) continue;
 					const opacity = template.document.getFlag('tokenmagic', 'templateData')?.opacity ?? 1;
 					if (template.texture && template.texture !== '') {
 						const { x: cx, y: cy } = template.center;

--- a/tokenmagic/module/tokenmagic.js
+++ b/tokenmagic/module/tokenmagic.js
@@ -856,8 +856,11 @@ export function TokenMagic() {
 		if (placeableType === PlaceableType.TEMPLATE) {
 			let updateData = placeable.document.getFlag('tokenmagic', 'templateData');
 			if (!(updateData == null)) {
-				placeable.document.tmfxTextureAlpha = placeable._TMFXgetSprite().alpha = updateData.opacity;
-				placeable.document.tmfxTint = updateData.tint;
+				const sprite = placeable._TMFXgetSprite();
+				if (sprite) {
+					placeable.document.tmfxTextureAlpha = sprite.alpha = updateData.opacity;
+					placeable.document.tmfxTint = updateData.tint;
+				}
 			}
 		} else if (placeableType === PlaceableType.REGION) {
 			const sprite = placeable._TMFXgetSprite();


### PR DESCRIPTION
## Summary

A `MeasuredTemplate` placeable can survive into `canvasReady` without `this.template` (its `PIXI.Graphics`) or a registered highlight layer:

- `loadTexture` rejects on a missing/failing fill texture and `_draw` aborts before `this.template = this.addChild(new PIXI.Graphics())`.
- The system migrated spell areas off `MeasuredTemplate` — PF2e v8 places `Region` documents instead, but legacy `MeasuredTemplate` documents from older PF2e versions are still present in scene data.
- The placeable was created in a state where the canvas hadn't finished initializing.

The bundle currently dereferences both unconditionally and throws on those.

## Repro

Foundry v14 + PF2e v8 world with any legacy `MeasuredTemplate` documents in a scene. On scene activation:

```
Error thrown in hooked function '' for hook 'canvasReady'.
Cannot set properties of undefined (setting 'alpha')
  at d (tokenmagic.js:859:70)
  at Object._loadFilters (tokenmagic.js:848:6)
  at Object.fn (tokenmagic.js:1762:8)
```

And then on every pointer move once `defaultTemplateOnHover` is on:

```
Uncaught TypeError: Cannot set properties of undefined (setting 'alpha')
  at ia.<anonymous> (settings.js:425:25)
```

## Changes

- `_singleLoadFilters` (`module/tokenmagic.js`): for the `TEMPLATE` branch, fetch `_TMFXgetSprite()` once and skip the alpha/tint assignments when it returns null/undefined. The `REGION` branch already guarded its sprite this way; this brings the template branch in line.
- `defaultTemplateOnHover` mousemove handler (`module/settings.js`): `continue` past templates whose `template.template` is missing, and past templates whose grid highlight layer didn't get registered (the previous expression `hl.renderable = …` crashed otherwise).

No behavioural change for templates that drew successfully — broken templates are simply skipped instead of taking down the canvasReady chain or the pointermove pipeline.

## Test plan

- [ ] Foundry v13 (verified): templates with valid textures still get their filters loaded and their hover dimming applied.
- [ ] Foundry v14 + PF2e v8 with a scene containing legacy `MeasuredTemplate` documents: canvasReady completes without throwing, pointer moves don't spam errors, and any healthy templates in the same scene still behave normally.
- [ ] Re-create / re-draw a template at runtime and confirm filters apply once `_draw` finishes.
